### PR TITLE
Update to 1.19.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19.1
 yarn_mappings=1.19.1+build.6
 loader_version=0.14.12
 # Mod Properties
-mod_version=1.5
+mod_version=1.6
 maven_group=ca.fxco
 archives_base_name=client_aatool
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.22
+minecraft_version=1.19.1
+yarn_mappings=1.19.1+build.6
 loader_version=0.12.12
 # Mod Properties
 mod_version=1.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.19.1
 yarn_mappings=1.19.1+build.6
-loader_version=0.12.12
+loader_version=0.14.12
 # Mod Properties
 mod_version=1.5
 maven_group=ca.fxco

--- a/src/main/java/ca/fxco/client_aatool/ClientCommands.java
+++ b/src/main/java/ca/fxco/client_aatool/ClientCommands.java
@@ -9,7 +9,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 
 import java.io.File;
 import java.util.Collection;
@@ -64,7 +64,7 @@ public class ClientCommands {
 
     public static void sendToPlayer(String str) {
         if (mc.player != null) {
-            mc.player.sendMessage(new LiteralText(str), false);
+            mc.player.sendMessage(Text.of(str), false);
         }
     }
 

--- a/src/main/java/ca/fxco/client_aatool/mixin/ClientPlayerEntity_clientCommandsMixin.java
+++ b/src/main/java/ca/fxco/client_aatool/mixin/ClientPlayerEntity_clientCommandsMixin.java
@@ -21,15 +21,12 @@ public class ClientPlayerEntity_clientCommandsMixin {
             cancellable = true
     )
     private void onSendCommand(String command, Text text, CallbackInfo ci) {
-        if (command.startsWith("/")) {
             StringReader reader = new StringReader(command);
-            reader.skip();
             int cursor = reader.getCursor();
             reader.setCursor(cursor);
-            if (ClientCommands.isClientSideCommand(command.substring(1).split(Pattern.quote(" ")))) {
+            if (ClientCommands.isClientSideCommand(command.split(Pattern.quote(" ")))) {
                 ClientCommands.executeCommand(reader);
                 ci.cancel();
             }
         }
-    }
 }

--- a/src/main/java/ca/fxco/client_aatool/mixin/ClientPlayerEntity_clientCommandsMixin.java
+++ b/src/main/java/ca/fxco/client_aatool/mixin/ClientPlayerEntity_clientCommandsMixin.java
@@ -3,6 +3,7 @@ package ca.fxco.client_aatool.mixin;
 import ca.fxco.client_aatool.ClientCommands;
 import com.mojang.brigadier.StringReader;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -16,10 +17,10 @@ public class ClientPlayerEntity_clientCommandsMixin {
 
     @Inject(
             at = @At("HEAD"),
-            method = "sendChatMessage(Ljava/lang/String;)V",
+            method = "sendCommand(Ljava/lang/String;Lnet/minecraft/text/Text;)V",
             cancellable = true
     )
-    private void onSendChatMessage(String message, CallbackInfo ci) {
+    private void onSendCommand(String message, Text text, CallbackInfo ci) {
         if (message.startsWith("/")) {
             StringReader reader = new StringReader(message);
             reader.skip();

--- a/src/main/java/ca/fxco/client_aatool/mixin/ClientPlayerEntity_clientCommandsMixin.java
+++ b/src/main/java/ca/fxco/client_aatool/mixin/ClientPlayerEntity_clientCommandsMixin.java
@@ -20,13 +20,13 @@ public class ClientPlayerEntity_clientCommandsMixin {
             method = "sendCommand(Ljava/lang/String;Lnet/minecraft/text/Text;)V",
             cancellable = true
     )
-    private void onSendCommand(String message, Text text, CallbackInfo ci) {
-        if (message.startsWith("/")) {
-            StringReader reader = new StringReader(message);
+    private void onSendCommand(String command, Text text, CallbackInfo ci) {
+        if (command.startsWith("/")) {
+            StringReader reader = new StringReader(command);
             reader.skip();
             int cursor = reader.getCursor();
             reader.setCursor(cursor);
-            if (ClientCommands.isClientSideCommand(message.substring(1).split(Pattern.quote(" ")))) {
+            if (ClientCommands.isClientSideCommand(command.substring(1).split(Pattern.quote(" ")))) {
                 ClientCommands.executeCommand(reader);
                 ci.cancel();
             }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
     "client_aatool.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.12.12",
+    "fabricloader": ">=0.14.12",
     "minecraft": "1.18.x"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.14.12",
-    "minecraft": "1.18.x"
+    "minecraft": ["1.19.1", "1.19.2", "1.19.3"]
   }
 }


### PR DESCRIPTION
Update to all sub-versions of 1.19 while dropping support for 1.18.x entirely. Note that 1.19 itself is not supported, as chat signing changed the way commands are handled within the client in 1.19.1.

I would recommend squashing the commits from this repository as I made many commits to make auditing this PR as painless as possible.